### PR TITLE
Uncommenting test for S3 creation through the API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ script:
   - docker exec -it provisioner ${ANSIBLE_HOME}/ansible-playbook ${PLAYBOOKS_PATH}/test_configure_oplog_store.yaml --extra-vars "mongodb_repo=${MONGO} om_download_url=${OM}"
   # Configure Filesystem Store
   - docker exec -it provisioner ${ANSIBLE_HOME}/ansible-playbook ${PLAYBOOKS_PATH}/test_configure_fsstore.yaml --extra-vars "mongodb_repo=${MONGO} om_download_url=${OM}"
-  # Configure S3 blockstore --> need further testing and improvements
-  # - docker exec -it provisioner ${ANSIBLE_HOME}/ansible-playbook ${PLAYBOOKS_PATH}/test_configure_s3_blockstore.yaml --extra-vars "mongodb_repo=${MONGO} om_download_url=${OM}"
+  # Configure S3 blockstore
+  - docker exec -it provisioner ${ANSIBLE_HOME}/ansible-playbook ${PLAYBOOKS_PATH}/test_configure_s3_blockstore.yaml --extra-vars "mongodb_repo=${MONGO} om_download_url=${OM}"

--- a/tasks/api-create-s3-blockstore.yaml
+++ b/tasks/api-create-s3-blockstore.yaml
@@ -44,7 +44,26 @@
         "uri": "mongodb://192.168.1.100:27017"
     }'
   when: om_version.stdout_lines[0] is version_compare("4.2","<")  
-  
+
+- name: Set Ops Manager URL for https
+  set_fact:
+    call_body: '{
+        "assignmentEnabled": true,
+        "awsAccessKey": "minio",
+        "awsSecretKey": "miniostorage",
+        "encryptedCredentials": false,
+        "id": "s3storage",
+        "labels": [],
+        "loadFactor": 1,
+        "pathStyleAccessEnabled": false,
+        "s3BucketEndpoint": "http://192.168.1.103:9000",
+        "s3BucketName": "ombucket",
+        "sseEnabled": false,
+        "ssl": false,
+        "uri": "mongodb://192.168.1.100:27017"
+    }'
+  when: om_version.stdout_lines[0] is version_compare("3.6","<=") 
+
 - name: "Printing result of API call"
   debug: var=call_body
 

--- a/tasks/api-create-s3-blockstore.yaml
+++ b/tasks/api-create-s3-blockstore.yaml
@@ -43,7 +43,7 @@
         "ssl": false,
         "uri": "mongodb://192.168.1.100:27017"
     }'
-  when: om_version.stdout_lines[0] is version_compare("4.2","<")  
+  when: om_version.stdout_lines[0] is version_compare("4.2","<") and om_version.stdout_lines[0] is version_compare("4.0",">=")
 
 - name: Set Ops Manager URL for https
   set_fact:
@@ -62,7 +62,7 @@
         "ssl": false,
         "uri": "mongodb://192.168.1.100:27017"
     }'
-  when: om_version.stdout_lines[0] is version_compare("3.6","<=") 
+  when: om_version.stdout_lines[0] is version_compare("4.0","<") 
 
 - name: "Printing result of API call"
   debug: var=call_body

--- a/tests/playbooks/test_configure_s3_blockstore.yaml
+++ b/tests/playbooks/test_configure_s3_blockstore.yaml
@@ -1,5 +1,5 @@
 - name: "Creating S3 blockstore in Ops Manager"
-  hosts: localhost
+  hosts: opsmgr
   become: yes
   gather_facts: no
   ignore_errors: no


### PR DESCRIPTION
This should resolve the issue with the API call regardless the version and restore the initial state of tests in Travis. 