### PR TITLE
Local mode for minio

### DIFF
--- a/files/.gitignore
+++ b/files/.gitignore
@@ -1,0 +1,2 @@
+*.rpm
+minio

--- a/tasks/install-s3.yaml
+++ b/tasks/install-s3.yaml
@@ -12,12 +12,22 @@
     url: "{{minio_url}}"
     dest: /opt/minio/bin/minio
     force_basic_auth: yes
-- name: "Adjusting file permissions"
+  when: not local_mode
+- name: "Adjusting minio binary permissions"
   file:
     path: /opt/minio/bin/minio
     owner: minio
     group: minio
     mode: 0744
+  when: not local mode
+- name: "Copy local minio binary"
+  copy: 
+    src: "../files/minio"
+    dest: "/opt/minio/bin/minio"
+    owner: minio 
+    group: minio 
+    mode: 0744
+  when: local_mode
 - name: "Placing minio configuration file"
   template: 
     src="../files/minio.conf"


### PR DESCRIPTION
It has been noticed that recently, the download endpoint for minio  has been considerably slow. 

This PR adds the possibility of installing `minio` in local mode. 