### PR TITLE
om_version added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN pip install --upgrade pip
 # Install latest (stable) Ansible version
 RUN pip install ansible
 
+# Install jmespath needed to parse json outputs
+RUN pip install jmespath
+
 # setup ssh
 RUN mkdir /root/.ssh
 ADD /inventory/clients/keys/id_rsa /root/.ssh/id_rsa
@@ -25,3 +28,4 @@ ADD files /root/files
 ADD vars /root/vars
 ADD tests /root/tests
 ADD om_ansible.yaml /root/om_ansible.yaml
+

--- a/tasks/install-om.yaml
+++ b/tasks/install-om.yaml
@@ -16,6 +16,45 @@
     enabled: yes
     state: restarted
 
+# Looking the Ops manager link based on the OM version requested in om_version
+
+- name: "Looking for OM version"
+  uri:
+    url: "https://s3.amazonaws.com/info-mongodb-com/com-download-center/ops_manager_{{om_version}}.json"
+    method: GET
+    return_content: yes
+    status_code: 200
+    body_format: json
+  register: json_om_version 
+  when: om_version is defined
+
+- set_fact:
+    platform_query: "platform[?arch=='x86_64']"
+    package_format_query: "[?package_format=='rpm'].packages"
+    link_query: "links[?name=='rpm'].download_link"
+  when: om_version is defined
+
+- set_fact:
+    om_packages: "{{json_om_version.json | json_query(platform_query) | json_query(package_format_query) }}"
+  when: om_version is defined
+
+# for 4.2.x responsed, packages is a doc, while in lower versions, it's a array
+- set_fact:
+    om_packages: "{{om_packages[0]}}"
+  when: om_packages[0][0] is defined
+
+- set_fact:
+    om_links: "{{ om_packages[0] | json_query(link_query) }}"
+  when: om_version is defined
+
+# Only set the om_download_url variable if it is not already set in the vars file
+# This is for the om_download_url take precedence over om_version 
+# in case a specific build is needed.
+
+- set_fact:
+    om_download_url: "{{ om_links[0] }}"
+  when: om_download_url is not defined
+
 - name: "Download Ops Manager RPM"
   get_url:
     url: "{{om_download_url}}"

--- a/vars/om-install-vars.yaml
+++ b/vars/om-install-vars.yaml
@@ -4,8 +4,12 @@ vms: false
 local_mode: false
 # MongoDB repositories for backing databases
 mongodb_repo: mongodb-org-4.2.repo
-# URL for Ops Manager packages
-om_download_url: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-4.2.12.56844.20200408T2127Z-1.x86_64.rpm
+# Ops Manaher version. (format: X.X.X)
+om_version: 4.2.14
+
+# URL for Ops Manager packages. If om_version was set, this setting will take precedence and overwrite it.
+# om_download_url: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-4.2.12.56844.20200408T2127Z-1.x86_64.rpm
+
 # First user login credentials
 om_username: admin
 om_password: Password1!


### PR DESCRIPTION
om_version variable added to get the link based on OM version instead of using the full build link.

**Note:** The full build link can still be used and takes precedence over the om_version.