### PR TITLE
Adding mongodb-org-4.4.repo for OM 4.4 installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vagrant
 *.rpm
 minio
-
+data/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - ANSIBLE_HOME=/usr/local/bin PLAYBOOKS_PATH=/root/tests/playbooks OM=${OM36} MONGO=${MONGO_REPO_36}
   - ANSIBLE_HOME=/usr/local/bin PLAYBOOKS_PATH=/root/tests/playbooks OM=${OM40} MONGO=${MONGO_REPO_40}
   - ANSIBLE_HOME=/usr/local/bin PLAYBOOKS_PATH=/root/tests/playbooks OM=${OM42} MONGO=${MONGO_REPO_42}
+  - ANSIBLE_HOME=/usr/local/bin PLAYBOOKS_PATH=/root/tests/playbooks OM=${OM44} MONGO=${MONGO_REPO_44}
   
 before_install:
   - sudo apt-get update

--- a/files/mongodb-org-4.4.repo
+++ b/files/mongodb-org-4.4.repo
@@ -1,0 +1,6 @@
+[mongodb-org-4.4]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.4/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-4.4.asc

--- a/tasks/api-create-s3-blockstore.yaml
+++ b/tasks/api-create-s3-blockstore.yaml
@@ -25,6 +25,7 @@
             "s3BucketEndpoint": "http://192.168.1.103:9000", 
             "s3BucketName": "ombucket",
             "sseEnabled": false,
+            "disableProxyS3": false,
             "ssl": false,
             "uri": "mongodb://192.168.1.100:27017",
             "acceptedTos":true
@@ -46,6 +47,7 @@
         "s3BucketEndpoint": "http://192.168.1.103:9000",
         "s3BucketName": "ombucket",
         "sseEnabled": false,
+        "disableProxyS3": false,
         "ssl": false,
         "uri": "mongodb://192.168.1.100:27017"
     }'
@@ -65,6 +67,7 @@
         "s3BucketEndpoint": "http://192.168.1.103:9000",
         "s3BucketName": "ombucket",
         "sseEnabled": false,
+        "disableProxyS3": false,
         "ssl": false,
         "uri": "mongodb://192.168.1.100:27017"
     }'

--- a/tasks/api-create-s3-blockstore.yaml
+++ b/tasks/api-create-s3-blockstore.yaml
@@ -22,7 +22,7 @@
             "labels": [],
             "loadFactor": 50,
             "s3MaxConnections":"50",
-            "s3BucketEndpoint": "http://192.168.1.103:9000", 
+            "s3BucketEndpoint": "http://192.168.1.103:9000",
             "s3BucketName": "ombucket",
             "sseEnabled": false,
             "disableProxyS3": false,
@@ -30,7 +30,27 @@
             "uri": "mongodb://192.168.1.100:27017",
             "acceptedTos":true
         }'
-  when: om_version is defined and om_version is version_compare("4.2",">=")  
+  when: om_version is defined and om_version is version_compare("4.4",">=")
+
+- name: Set Ops Manager URL for https
+  set_fact:
+    call_body: '{  "assignmentEnabled": true,
+            "awsAccessKey": "minio",
+            "awsSecretKey": "miniostorage",
+            "pathStyleAccessEnabled":false,
+            "encryptedCredentials": false,
+            "id": "s3Store",
+            "labels": [],
+            "loadFactor": 50,
+            "s3MaxConnections":"50",
+            "s3BucketEndpoint": "http://192.168.1.103:9000",
+            "s3BucketName": "ombucket",
+            "sseEnabled": false,
+            "ssl": false,
+            "uri": "mongodb://192.168.1.100:27017",
+            "acceptedTos":true
+        }'
+  when: om_version is defined and om_version is version_compare("4.4","<") and om_version is version_compare("4.2",">=")
 
 - name: Set Ops Manager URL for https
   set_fact:
@@ -47,7 +67,6 @@
         "s3BucketEndpoint": "http://192.168.1.103:9000",
         "s3BucketName": "ombucket",
         "sseEnabled": false,
-        "disableProxyS3": false,
         "ssl": false,
         "uri": "mongodb://192.168.1.100:27017"
     }'
@@ -67,11 +86,10 @@
         "s3BucketEndpoint": "http://192.168.1.103:9000",
         "s3BucketName": "ombucket",
         "sseEnabled": false,
-        "disableProxyS3": false,
         "ssl": false,
         "uri": "mongodb://192.168.1.100:27017"
     }'
-  when: om_version is defined and om_version is version_compare("4.0","<") 
+  when: om_version is defined and om_version is version_compare("4.0","<")
 
 - name: "Printing API call body"
   debug: var=call_body

--- a/tasks/install-automation-agent.yaml
+++ b/tasks/install-automation-agent.yaml
@@ -1,36 +1,36 @@
 ---
 - name: "Copy mongodb repository files"
-  template: 
+  template:
     src="../files/{{mongodb_repo}}"
     dest="/etc/yum.repos.d/{{mongodb_repo}}"
-    owner=root 
-    group=root 
+    owner=root
+    group=root
     mode="u=rw,g=r,o=r"
 - name: "Install mongodb shell"
   yum: name=mongodb-org-shell state=latest
 
 - name: "Install MongoDB Enterprise dependencies"
-  yum: 
+  yum:
     name: "{{ packages }}"
     state: present
   vars:
     packages:
-        - cyrus-sasl 
-        - cyrus-sasl-gssapi 
-        - cyrus-sasl-plain 
-        - krb5-libs 
-        - libcurl 
-        - libpcap 
-        - lm_sensors-libs 
-        - net-snmp 
-        - net-snmp-agent-libs 
-        - openldap 
-        - openssl 
-        - rpm-libs 
+        - cyrus-sasl
+        - cyrus-sasl-gssapi
+        - cyrus-sasl-plain
+        - krb5-libs
+        - libcurl
+        - libpcap
+        - lm_sensors-libs
+        - net-snmp
+        - net-snmp-agent-libs
+        - openldap
+        - openssl
+        - rpm-libs
         - tcp_wrappers-libs
 
 - name: get automation groupid
-  shell: mongo omserver.omansible.int:27017 --quiet --eval "print(db.getSiblingDB('mmsdbconfig').config.customers.findOne()._id.str)" 
+  shell: mongo omserver.omansible.int:27017 --quiet --eval "print(db.getSiblingDB('mmsdbconfig').config.customers.findOne()._id.str)"
   register: opsmanager_groupid
 - debug: var=opsmanager_groupid
 
@@ -59,7 +59,7 @@
   when: not mongodb_repo == "mongodb-org-3.4.repo"
 
 - name: download automation agent
-  get_url: 
+  get_url:
     url: "{{ om_url }}/download/agent/automation/mongodb-mms-automation-agent-manager-latest.x86_64.rhel7.rpm" 
     dest: "/tmp/automation-agent.rpm"
     validate_certs: no
@@ -95,7 +95,7 @@
   lineinfile:
     path: /etc/mongodb-mms/automation-agent.config
     regexp: '^mmsBaseUrl='
-    line: 'mmsBaseUrl={{ om_url }}'  
+    line: 'mmsBaseUrl={{ om_url }}'
 
 - name: Configure trusted MMS certificate parameter
   lineinfile:

--- a/tasks/install-backing-dbs.yaml
+++ b/tasks/install-backing-dbs.yaml
@@ -10,34 +10,34 @@
   yum: name=* state=latest
   when: vms
 - name: "Install MongoDB Enterprise dependencies"
-  yum: 
+  yum:
     name: "{{ packages }}"
     state: present
   vars:
     packages:
-        - cyrus-sasl 
-        - cyrus-sasl-gssapi 
-        - cyrus-sasl-plain 
-        - krb5-libs 
-        - libcurl 
-        - libpcap 
-        - lm_sensors-libs 
-        - net-snmp 
-        - net-snmp-agent-libs 
-        - openldap 
-        - openssl 
-        - rpm-libs 
+        - cyrus-sasl
+        - cyrus-sasl-gssapi
+        - cyrus-sasl-plain
+        - krb5-libs
+        - libcurl
+        - libpcap
+        - lm_sensors-libs
+        - net-snmp
+        - net-snmp-agent-libs
+        - openldap
+        - openssl
+        - rpm-libs
         - tcp_wrappers-libs
 - name: "Install mongodb"
   yum: name=mongodb-org state=latest
 - name: "Create dbpath for Application Database"
   file: path=/data/appdb state=directory mode=0755 owner=mongod group=mongod
 - name: "Copy mongod configuration file"
-  template: 
+  template:
     src="../files/mongod.conf"
     dest="/etc/mongod.conf"
-    owner=root 
-    group=root 
+    owner=root
+    group=root
     mode="u=rw,g=r,o=r"
 - name: "Enable mongod service"
   service:

--- a/tasks/install-om.yaml
+++ b/tasks/install-om.yaml
@@ -8,7 +8,7 @@
   lineinfile:
     path: /etc/postfix/main.cf
     regexp: '^inet_protocols =.*'
-    line: 'inet_protocols = ipv4'
+    line: 'inet_protocols = ipv4'    
 
 - name: "Starting Postfix"
   service:
@@ -25,7 +25,7 @@
     return_content: yes
     status_code: 200
     body_format: json
-  register: json_om_version
+  register: json_om_version 
   when: om_version is defined
 
 - set_fact:
@@ -63,11 +63,11 @@
   when: not local_mode
 
 - name: "Copy the local installer"
-  copy:
+  copy: 
     src="../files/mongodb-mms.rpm"
     dest="/tmp/mongodb-mms.rpm"
-    owner=root
-    group=root
+    owner=root 
+    group=root 
     mode="u=rwx,g=r,o=r"
   when: local_mode
 
@@ -109,7 +109,7 @@
   lineinfile:
     path: /opt/mongodb/mms/conf/conf-mms.properties
     regexp: '^mms.https.PEMKeyFile=.*'
-    line: 'mms.https.PEMKeyFile=/certs/omserver_server.pem'
+    line: 'mms.https.PEMKeyFile=/certs/omserver_server.pem'    
   when: om_https
 
 - name: Replacing mongoUri

--- a/tasks/install-om.yaml
+++ b/tasks/install-om.yaml
@@ -8,7 +8,7 @@
   lineinfile:
     path: /etc/postfix/main.cf
     regexp: '^inet_protocols =.*'
-    line: 'inet_protocols = ipv4'    
+    line: 'inet_protocols = ipv4'
 
 - name: "Starting Postfix"
   service:
@@ -25,7 +25,7 @@
     return_content: yes
     status_code: 200
     body_format: json
-  register: json_om_version 
+  register: json_om_version
   when: om_version is defined
 
 - set_fact:
@@ -63,11 +63,11 @@
   when: not local_mode
 
 - name: "Copy the local installer"
-  copy: 
+  copy:
     src="../files/mongodb-mms.rpm"
     dest="/tmp/mongodb-mms.rpm"
-    owner=root 
-    group=root 
+    owner=root
+    group=root
     mode="u=rwx,g=r,o=r"
   when: local_mode
 
@@ -109,7 +109,7 @@
   lineinfile:
     path: /opt/mongodb/mms/conf/conf-mms.properties
     regexp: '^mms.https.PEMKeyFile=.*'
-    line: 'mms.https.PEMKeyFile=/certs/omserver_server.pem'    
+    line: 'mms.https.PEMKeyFile=/certs/omserver_server.pem'
   when: om_https
 
 - name: Replacing mongoUri

--- a/tasks/install-s3.yaml
+++ b/tasks/install-s3.yaml
@@ -8,7 +8,7 @@
 - name: "Create data directory"
   file: path=/opt/minio/data state=directory mode=0755 owner=minio group=minio
 - name: "Downloading minio binary"
-  get_url: 
+  get_url:
     url: "{{minio_url}}"
     dest: /opt/minio/bin/minio
     force_basic_auth: yes
@@ -21,21 +21,21 @@
     mode: 0744
   when: not local_mode
 - name: "Copy local minio binary"
-  copy: 
+  copy:
     src: "../files/minio"
     dest: "/opt/minio/bin/minio"
-    owner: minio 
-    group: minio 
+    owner: minio
+    group: minio
     mode: 0744
   when: local_mode
 - name: "Placing minio configuration file"
-  template: 
+  template:
     src="../files/minio.conf"
     dest="/opt/minio/minio.conf"
     owner=minio
     group=minio
 - name: "Setting up minio as a systemd service"
-  template: 
+  template:
     src="../files/minio.service"
     dest="/etc/systemd/system/minio.service"
 - name: "Enable minio service"

--- a/tasks/prepare-ldapserver.yaml
+++ b/tasks/prepare-ldapserver.yaml
@@ -20,7 +20,7 @@
   lineinfile:
     path: /etc/default/slapd
     regexp: '^SLAPD_SERVICES=.*'
-    line: 'SLAPD_SERVICES="ldap:/// ldapi:/// ldaps:///"'    
+    line: 'SLAPD_SERVICES="ldap:/// ldapi:/// ldaps:///"'
 
 - name: "Configuring client ldap settings"
   lineinfile:

--- a/tasks/ssl-creation.yaml
+++ b/tasks/ssl-creation.yaml
@@ -153,7 +153,7 @@
     src: /root/files/ssl/{{ item.item }}_client.crt
     dest: /root/files/ssl/{{ item.item }}_client.pem
   with_items: "{{ clientpemstat.results }}"
-  when: item.stat.exists == false  
+  when: item.stat.exists == false
 
 - name: Client cert + key concatenation
   lineinfile:
@@ -164,7 +164,7 @@
   when: item.stat.exists == false
 
 - name: Checking if server pem file exists
-  stat: 
+  stat:
     path: /root/files/ssl/{{ item }}_server.pem
   register: serverpemstat
   with_items:
@@ -221,7 +221,7 @@
     src: /root/files/ssl/{{ item.item }}_server.crt
     dest: /root/files/ssl/{{ item.item }}_server.pem
   with_items: "{{ serverpemstat.results }}"
-  when: item.stat.exists == false  
+  when: item.stat.exists == false
 
 - name: Server cert + key concatenation
   lineinfile:
@@ -232,7 +232,7 @@
   when: item.stat.exists == false
 
 - name: Checking if internal pem file exists
-  stat: 
+  stat:
     path: /root/files/ssl/{{ item }}_internal.pem
   register: internalpemstat
   with_items:

--- a/tests/playbooks/test_create_ssl_certs.yaml
+++ b/tests/playbooks/test_create_ssl_certs.yaml
@@ -8,7 +8,7 @@
       include: ../../tasks/ssl-creation.yaml
 
 - name: "Distributing CA on all hosts"
-  hosts: all 
+  hosts: all
   become: yes
   gather_facts: no
   tasks:
@@ -25,7 +25,7 @@
         mode="u=rw,g=r,o=r"
 
 - name: "Distributing queryable.pem on Ops Manager host"
-  hosts: opsmgr 
+  hosts: opsmgr
   become: yes
   gather_facts: no
   tasks:

--- a/vars/om-install-vars.yaml
+++ b/vars/om-install-vars.yaml
@@ -5,7 +5,7 @@ local_mode: false
 # MongoDB repositories for backing databases
 mongodb_repo: mongodb-org-4.2.repo
 # Ops Manaher version. (format: X.X.X)
-om_version: 4.2.15
+om_version: 4.4.0
 
 # URL for Ops Manager packages. If om_version was set, this setting will take precedence and overwrite it.
 # om_download_url: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-4.2.12.56844.20200408T2127Z-1.x86_64.rpm

--- a/vars/om-install-vars.yaml
+++ b/vars/om-install-vars.yaml
@@ -5,7 +5,7 @@ local_mode: false
 # MongoDB repositories for backing databases
 mongodb_repo: mongodb-org-4.2.repo
 # Ops Manaher version. (format: X.X.X)
-om_version: 4.2.14
+om_version: 4.4.0
 
 # URL for Ops Manager packages. If om_version was set, this setting will take precedence and overwrite it.
 # om_download_url: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-4.2.12.56844.20200408T2127Z-1.x86_64.rpm

--- a/vars/om-install-vars.yaml
+++ b/vars/om-install-vars.yaml
@@ -5,7 +5,7 @@ local_mode: false
 # MongoDB repositories for backing databases
 mongodb_repo: mongodb-org-4.2.repo
 # Ops Manaher version. (format: X.X.X)
-om_version: 4.4.0
+om_version: 4.2.15
 
 # URL for Ops Manager packages. If om_version was set, this setting will take precedence and overwrite it.
 # om_download_url: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-4.2.12.56844.20200408T2127Z-1.x86_64.rpm


### PR DESCRIPTION
New Ops Manager 4.4.0 needs mongodb-org-4.4.repo to be installed.

S3 Blockstore in OM 4.4 has a new parameter: disableProxyS3. Calling the OM API without this new parameter will fail to configure the S3 Blockstore.

Removed unnecessary spaces at the end of several lines/files.