### PR TITLE
Adding httpsCAFile option for agent TLS settings

### DIFF
--- a/tasks/install-automation-agent.yaml
+++ b/tasks/install-automation-agent.yaml
@@ -102,7 +102,14 @@
     path: /etc/mongodb-mms/automation-agent.config
     regexp: '^sslTrustedMMSServerCertificate='
     line: 'sslTrustedMMSServerCertificate=/certs/ca.pem'
-  when: om_https
+  when: om_https and om_version is version_compare("4.4","<")
+
+- name: Configure trusted MMS certificate parameter
+  lineinfile:
+    path: /etc/mongodb-mms/automation-agent.config
+    regexp: '^httpsCAFile='
+    line: 'httpsCAFile=/certs/ca.pem'
+  when: om_https and om_version is version_compare("4.4",">=")
 
 - name: setup data directory
   file: path=/data state=directory mode=0755 owner=mongod group=mongod

--- a/vars/om-install-vars.yaml
+++ b/vars/om-install-vars.yaml
@@ -3,9 +3,9 @@
 vms: false
 local_mode: false
 # MongoDB repositories for backing databases
-mongodb_repo: mongodb-org-4.2.repo
+mongodb_repo: mongodb-org-4.4.repo
 # Ops Manaher version. (format: X.X.X)
-om_version: 4.4.0
+om_version: 4.4.7
 
 # URL for Ops Manager packages. If om_version was set, this setting will take precedence and overwrite it.
 # om_download_url: https://downloads.mongodb.com/on-prem-mms/rpm/mongodb-mms-4.2.12.56844.20200408T2127Z-1.x86_64.rpm


### PR DESCRIPTION
Ops Manager 4.4 replaced the "sslTrustedMMSServerCertificate" option with "httpsCAFile" for the Agent configuration to use TLS.

Logic for Ops Manager >=4.4 and < 4.4 added.