### PR TITLE
Raised mem for ldapserver container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
     hostname: ldapserver.omansible.int
     domainname: omansible.int
     container_name: ldapserver
-    mem_limit: 500m
+    mem_limit: 768m
     cap_add:
       - SYS_ADMIN
     volumes:


### PR DESCRIPTION
Raised memory for ldapserver to 768m to fix travis builds OOMs.