### PR TITLE
Create mongodb-org-6.0.repo file

### DIFF
--- a/files/mongodb-org-6.0.repo
+++ b/files/mongodb-org-6.0.repo
@@ -1,0 +1,6 @@
+[mongodb-org-6.0]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/6.0/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-6.0.asc


### PR DESCRIPTION
Add MongoDB 6.0 repo to allow Ops Manager 6.X installation.