### PR TITLE
add a forking type so that the Application Database keeps running after forking

### DIFF
--- a/tasks/install-backing-dbs.yaml
+++ b/tasks/install-backing-dbs.yaml
@@ -48,7 +48,7 @@
 - name: "Increase SystemD timeout for mongod service and add a forking Type"
   copy:
     content: "[Service]\nTimeoutStartSec=900\nType=forking"
-    dest: "/etc/systemd/system/mongod.service.d/increase-timeout.conf"
+    dest: "/etc/systemd/system/mongod.service.d/additional.conf"
 - name: "Enable mongod service"
   service:
     name: mongod

--- a/tasks/install-backing-dbs.yaml
+++ b/tasks/install-backing-dbs.yaml
@@ -45,9 +45,9 @@
   file:
     path: /etc/systemd/system/mongod.service.d
     state: directory
-- name: "Increase SystemD timeout for mongodb-mms service"
+- name: "Increase SystemD timeout for mongod service and add a forking Type"
   copy:
-    content: "[Service]\nTimeoutStartSec=900"
+    content: "[Service]\nTimeoutStartSec=900\nType=forking"
     dest: "/etc/systemd/system/mongod.service.d/increase-timeout.conf"
 - name: "Enable mongod service"
   service:


### PR DESCRIPTION
This fixes the Application Database failing to continue running. Once started it exits with code 0 because systemd keeps telling it to terminate. When we tell systemd that mongod will fork, it no longer does this.