### PR TITLE
don't refer to non existent pid path

### DIFF
--- a/files/mongod.conf
+++ b/files/mongod.conf
@@ -17,7 +17,6 @@ storage:
 # how the process runs
 processManagement:
   fork: true  # fork and run in background
-  pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
 
 # network interfaces
 net:


### PR DESCRIPTION
updated mongod packages don't have this created by default, so mongod fails to start