### PR TITLE
Minio UI console issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once the infrastructure has been provisioned, the following UIs can be accessed:
    - URL: http://localhost:8080 or https://omserver.omansible.int:8443 if [https for Ops Manager](https://github.com/HenryGP/om_ansible/wiki/Security#https-for-ops-manager-server-) was enabled. (you would need to setup an alias in your etc/hosts to allow TLS/SSL certificate validation to succeed). 
    - User: admin
    - Password: Password1!
-- S3 minio UI: http://localhost:9000
+- S3 minio UI: http://localhost:9090
    - Access key: minio
    - Secret key: miniostorage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
     ports:
       - "22"
       - "9000:9000"
+      - "9090:9090"
     privileged: true
     networks:
       front:

--- a/files/minio.service
+++ b/files/minio.service
@@ -16,7 +16,7 @@ PermissionsStartOnly=true
 EnvironmentFile=-/opt/minio/minio.conf
 ExecStartPre=/bin/bash -c "[ -n \"${MINIO_VOLUMES}\" ] || echo \"Variable MINIO_VOLUMES not set in /opt/minio/minio.conf\""
 
-ExecStart=/opt/minio/bin/minio server $MINIO_OPTS $MINIO_VOLUMES
+ExecStart=/opt/minio/bin/minio server $MINIO_OPTS $MINIO_VOLUMES --console-address ":9090"
 
 StandardOutput=journal
 StandardError=inherit


### PR DESCRIPTION
Minio S3 console UI port 9000 doesn't work for Docker as now it relies on a [dynamic port assignment](https://min.io/docs/minio/linux/administration/minio-console.html#id4) which is incompatible with port exposure in Docker.
The fix consists in the following steps:
- Exposing port 9090 for s3 container
- Editing s3 service definition, making the port static
- Modifying the readme.md to reflect the change